### PR TITLE
Fix typo in runnable_userdata.sh

### DIFF
--- a/script/runnable_userdata.sh
+++ b/script/runnable_userdata.sh
@@ -80,7 +80,7 @@ install_tools(){
 
     # Install kubectl v1.24
     #curl -o /tmp/kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.24.10/2023-01-30/bin/linux/amd64/kubectl
-    curl -O /tmp/kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.29.0/2024-01-04/bin/linux/amd64/kubectl
+    curl -o /tmp/kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.29.0/2024-01-04/bin/linux/amd64/kubectl
 
     sudo mv /tmp/kubectl /usr/local/bin
     chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
There was a typo in the parameters while downloading kubectl from a remote using curl.